### PR TITLE
Added option for S3 CacheControl header

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -391,6 +391,12 @@
               "description": "This will prepend a prefix to any file uploaded to S3.  For dynamically created prefixes, you can use the following variables: <code>@{date:format}<\/code>, <code>@{site-name}<\/code>, <code>@{site-host}<\/code>, <code>@{user-name}<\/code>, <code>@{unique-id}<\/code>, <code>@{unique-path}<\/code>.  For the date token, format is any format string that you can use with php's date() function.  Note that specifying a prefix here will remove WordPress's default date prefix.  WordPress's default prefix would look like: <code>@{date:Y\/m}<\/code>",
               "type": "text-field",
               "watch": true
+            },
+            "ilab-media-s3-cache-control": {
+              "title": "AWS S3 Cache Control",
+              "description": "e.g. public,max-age=2592000 - If you are supplying this value through a .env file, or environment variables, the key is: <strong>ILAB_AWS_S3_BUCKET</strong>",
+              "type": "text-field",
+              "watch": true
             }
           }
         },


### PR DESCRIPTION
Enable media to have a default Cache-Control header set via the s3 upload params from an admin option