### PR TITLE
Enable translations through translation.wordpress.org

### DIFF
--- a/ilab-media-tools.php
+++ b/ilab-media-tools.php
@@ -4,6 +4,7 @@ Plugin Name: Media Cloud
 Plugin URI: http://interfacelab.com/media-tools
 Description: Automatically upload media to Amazon S3 and integrate with Imgix, a real-time image processing CDN.  Boosts site performance and simplifies workflows.
 Author: interfacelab
+Text Domain: ilab-media-tools
 Version: 2.1.0
 Author URI: http://interfacelab.io
 */


### PR DESCRIPTION
Adding Text Domain to the WordPress comments in the main file. This should enable translations to be done through translation.wordpress.org: https://translate.wordpress.org/projects/wp-plugins/ilab-media-tools

![screen shot 2017-12-31 at 2 07 31 pm](https://user-images.githubusercontent.com/1820367/34459739-fc507726-ee33-11e7-9829-d9f6dd1a320e.png)

Error message can be found here: https://wordpress.slack.com/archives/C0E7F4RND/p1507202684000203