### PR TITLE
Fix S3 object path link

### DIFF
--- a/classes/Cloud/Storage/Driver/S3/S3Storage.php
+++ b/classes/Cloud/Storage/Driver/S3/S3Storage.php
@@ -152,16 +152,15 @@ class S3Storage implements StorageInterface {
 		return null;
 	}
 
-
 	public static function bucketLink($bucket) {
 		return "https://console.aws.amazon.com/s3/buckets/$bucket";
 	}
 
 	public static function pathLink($bucket, $key) {
-		return "https://console.aws.amazon.com/s3/buckets/{$bucket}/{$key}/details";
+		return "https://console.aws.amazon.com/s3/object/{$bucket}/{$key}";
 	}
 	//endregion
-	
+
 	//region Enabled/Options
 	public function supportsDirectUploads() {
 		return (StorageManager::driver() == 's3');


### PR DESCRIPTION
The current path is built with
`https://console.aws.amazon.com/s3/buckets/{$bucket}/{$key}/details`

But it should be 
`https://console.aws.amazon.com/s3/object/{$bucket}/{$key}`
