### PR TITLE
Use credential provider for AWS S3

### DIFF
--- a/classes/Cloud/Storage/Driver/S3/S3Storage.php
+++ b/classes/Cloud/Storage/Driver/S3/S3Storage.php
@@ -224,7 +224,7 @@ class S3Storage implements StorageInterface {
 	}
 
 	public function enabled() {
-		if(!(($this->key && $this->secret) || $this->useCredentialProvider) && !$this->bucket)) {
+		if(!(($this->key && $this->secret) || $this->useCredentialProvider) && !$this->bucket) {
 			NoticeManager::instance()->displayAdminNotice('error', "To start using Cloud Storage, you will need to <a href='admin.php?page=media-tools-s3'>supply your AWS credentials.</a>.");
 
 			return false;

--- a/config/storage.config.php
+++ b/config/storage.config.php
@@ -62,8 +62,8 @@ return [
 						]
 					],
 					"ilab-media-s3-credential-provider" => [
-						"title" => "Secret",
-						"description" => "If you are supplying this value through a .env file, or environment variables, the key is: <strong>ILAB_AWS_S3_ACCESS_SECRET</strong>",
+						"title" => "Use credential provider",
+						"description" => "If you are supplying this value through a .env file, or environment variables, the key is: <strong>ILAB_AWS_S3_USE_CREDENTIAL_PROVIDER</strong>",
 						"type" => "checkbox",
 						"watch" => false,
 						"conditions" => [

--- a/config/storage.config.php
+++ b/config/storage.config.php
@@ -61,6 +61,15 @@ return [
 							"ilab-media-storage-provider" => ["!google", "!backblaze"]
 						]
 					],
+					"ilab-media-s3-credential-provider" => [
+						"title" => "Secret",
+						"description" => "If you are supplying this value through a .env file, or environment variables, the key is: <strong>ILAB_AWS_S3_ACCESS_SECRET</strong>",
+						"type" => "checkbox",
+						"watch" => false,
+						"conditions" => [
+							"ilab-media-storage-provider" => ["s3"]
+						]
+					],
 					"ilab-media-backblaze-account-id" => [
 						"title" => "Account Id",
 						"description" => "If you are supplying this value through a .env file, or environment variables, the key is: <strong>ILAB_BACKBLAZE_ACCOUNT_ID</strong>",


### PR DESCRIPTION
This simple fix adds the ability for this tool to use the default credential provider, allowing AWS SDK to pull the keys directly from within the EC2 VM