### PR TITLE
Allow environment variables to halt option lookups

### DIFF
--- a/classes/Cloud/Storage/Driver/S3/S3Storage.php
+++ b/classes/Cloud/Storage/Driver/S3/S3Storage.php
@@ -111,8 +111,8 @@ class S3Storage implements StorageInterface {
 				], true);
 			}
 		}
-
-		$this->settingsError = get_option($this->settingsErrorOptionName(), false);
+		
+		$this->settingsError = EnvironmentOptions::Option($this->settingsErrorOptionName(), 'ILAB_MEDIA_S3_SETTINGS_ERROR', false);
 
 		if ($thisClass::defaultRegion() !== null) {
 			$this->region = $thisClass::defaultRegion();

--- a/classes/Tools/Debugging/DebuggingTool.php
+++ b/classes/Tools/Debugging/DebuggingTool.php
@@ -27,8 +27,8 @@ class DebuggingTool extends ToolBase {
 	public function __construct( $toolName, $toolInfo, $toolManager ) {
 		parent::__construct( $toolName, $toolInfo, $toolManager );
 
-		$paperTrailEndPoint = get_option('ilab-media-s3-debug-papertrail-endpoint', false);
-		$paperTrailPort = get_option('ilab-media-s3-debug-papertrail-port', false);
+		$paperTrailEndPoint = $this->getOption('ilab-media-s3-debug-papertrail-endpoint', 'ILAB_MEDIA_S3_DEBUG_PAPERTRAIL_ENDPOINT', false);
+		$paperTrailPort = $this->getOption('ilab-media-s3-debug-papertrail-port', 'ILAB_MEDIA_S3_DEBUG_PAPERTRAIL_PORT', false);
 
 		if (!empty($paperTrailEndPoint) && !empty($paperTrailPort)) {
 			if (!function_exists('socket_create') && $this->enabled()) {

--- a/classes/Tools/Debugging/DebuggingTool.php
+++ b/classes/Tools/Debugging/DebuggingTool.php
@@ -27,12 +27,14 @@ class DebuggingTool extends ToolBase {
 	public function __construct( $toolName, $toolInfo, $toolManager ) {
 		parent::__construct( $toolName, $toolInfo, $toolManager );
 
-		$paperTrailEndPoint = $this->getOption('ilab-media-s3-debug-papertrail-endpoint', 'ILAB_MEDIA_S3_DEBUG_PAPERTRAIL_ENDPOINT', false);
-		$paperTrailPort = $this->getOption('ilab-media-s3-debug-papertrail-port', 'ILAB_MEDIA_S3_DEBUG_PAPERTRAIL_PORT', false);
+		if ( $this->enabled() ) {
+			$paperTrailEndPoint = $this->getOption('ilab-media-s3-debug-papertrail-endpoint', 'ILAB_MEDIA_S3_DEBUG_PAPERTRAIL_ENDPOINT', false);
+			$paperTrailPort = $this->getOption('ilab-media-s3-debug-papertrail-port', 'ILAB_MEDIA_S3_DEBUG_PAPERTRAIL_PORT', false);
 
-		if (!empty($paperTrailEndPoint) && !empty($paperTrailPort)) {
-			if (!function_exists('socket_create') && $this->enabled()) {
-				NoticeManager::instance()->displayAdminNotice('error', 'You have specified papertrail endpoint and ports, but you are missing the <a href="http://php.net/manual/en/book.sockets.php" target=_blank>php socket extension</a>.  Please install this extension to use remote logging.');
+			if (!empty($paperTrailEndPoint) && !empty($paperTrailPort)) {
+				if (!function_exists('socket_create') && $this->enabled()) {
+					NoticeManager::instance()->displayAdminNotice('error', 'You have specified papertrail endpoint and ports, but you are missing the <a href="http://php.net/manual/en/book.sockets.php" target=_blank>php socket extension</a>.  Please install this extension to use remote logging.');
+				}
 			}
 		}
 	}

--- a/classes/Tools/Rekognition/RekognitionTool.php
+++ b/classes/Tools/Rekognition/RekognitionTool.php
@@ -94,7 +94,7 @@ class RekognitionTool extends ToolBase {
 		$this->detectLabelsConfidence = min(100, max(0, $this->detectLabelsConfidence));
 		$this->detectExplicitConfidence = min(100, max(0, $this->detectExplicitConfidence));
 
-		$toIgnoreString = get_option('ilab-media-s3-rekognition-ignored-tags', '');
+		$toIgnoreString = $this->getOption('ilab-media-s3-rekognition-ignored-tags', 'ILAB_AWS_REKOGNITION_IGNORED_TAGS', '');
 		if (!empty($toIgnoreString)) {
 			$toIgnore = explode(',', $toIgnoreString);
 			foreach($toIgnore as $ignoredTag) {

--- a/classes/Tools/ToolBase.php
+++ b/classes/Tools/ToolBase.php
@@ -91,7 +91,7 @@ abstract class ToolBase {
 	    $this->only_when_enabled = false;
 
         if (isset($toolInfo['env'])) {
-        	$this->env_variable = $toolInfo['env'];
+            $this->env_variable = $toolInfo['env'];
         }
 
         if (isset($toolInfo['settings']) && !empty($toolInfo['settings'])) {
@@ -148,8 +148,7 @@ abstract class ToolBase {
      */
     public function enabled()
     {
-    	$env = ($this->env_variable) ? getenv($this->env_variable) : false;
-        $enabled=get_option("ilab-media-tool-enabled-$this->toolName", $env);
+        $enabled=$this->getOption("ilab-media-tool-enabled-$this->toolName", $this->env_variable, false);
 
         if ($enabled && isset($this->toolInfo['dependencies']))
         {

--- a/classes/Utilities/EnvironmentOptions.php
+++ b/classes/Utilities/EnvironmentOptions.php
@@ -41,13 +41,13 @@ final class EnvironmentOptions {
 		if (is_array($envVariableName)) {
 			foreach($envVariableName as $envVariable) {
 				$envval = getenv($envVariable);
-				if (!empty($envval)) {
+				if ($envval !== false) {
 					return $envval;
 				}
 			}
 		} else {
 			$envval = getenv($envVariableName);
-			if (empty($envval)) {
+			if ($envval !== false) {
 				return $envval;
 			}
 		}

--- a/classes/Utilities/EnvironmentOptions.php
+++ b/classes/Utilities/EnvironmentOptions.php
@@ -41,13 +41,13 @@ final class EnvironmentOptions {
 		if (is_array($envVariableName)) {
 			foreach($envVariableName as $envVariable) {
 				$envval = getenv($envVariable);
-				if ($envval) {
+				if (!empty($envval)) {
 					return $envval;
 				}
 			}
 		} else {
 			$envval = getenv($envVariableName);
-			if ($envval) {
+			if (empty($envval)) {
 				return $envval;
 			}
 		}

--- a/classes/Utilities/Logger.php
+++ b/classes/Utilities/Logger.php
@@ -16,6 +16,7 @@ namespace ILAB\MediaCloud\Utilities;
 use Monolog\Handler\ErrorLogHandler;
 use Monolog\Handler\SyslogUdpHandler;
 use Monolog\Logger as MonologLogger;
+use ILAB\MediaCloud\Utilities\EnvironmentOptions;
 
 if (!defined( 'ABSPATH')) { header( 'Location: /'); die; }
 
@@ -30,8 +31,7 @@ class Logger {
 
 	//region Constructor
 	public function __construct() {
-		$env = getenv('ILAB_MEDIA_DEBUGGING_ENABLED');
-		$enabled=get_option("ilab-media-tool-enabled-debugging", $env);
+		$enabled=EnvironmentOptions::Option("ilab-media-tool-enabled-debugging", 'ILAB_MEDIA_DEBUGGING_ENABLED', false);
 
 		if ($enabled) {
 			$level = get_option('ilab-media-s3-debug-logging-level', 'none');
@@ -52,8 +52,8 @@ class Logger {
 				$this->logger = new MonologLogger('ilab-media-tool');
 				$this->logger->pushHandler(new ErrorLogHandler(ErrorLogHandler::OPERATING_SYSTEM, $realLevel));
 
-				$paperTrailEndPoint = get_option('ilab-media-s3-debug-papertrail-endpoint', false);
-				$paperTrailPort = get_option('ilab-media-s3-debug-papertrail-port', false);
+				$paperTrailEndPoint = EnvironmentOptions::Option('ilab-media-s3-debug-papertrail-endpoint', 'ILAB_MEDIA_S3_DEBUG_PAPERTRAIL_ENDPOINT', false);
+				$paperTrailPort = EnvironmentOptions::Option('ilab-media-s3-debug-papertrail-port', 'ILAB_MEDIA_S3_DEBUG_PAPERTRAIL_PORT', false);
 
 				if (!empty($paperTrailEndPoint) && !empty($paperTrailPort)) {
 					if (function_exists('socket_create')) {


### PR DESCRIPTION
Reduces database queries for disabled tools by allow env variables to halt option lookups. This process is already used in many places throughout the code so this is just an addition to include more places such as checking it a tool is enabled.