### PR TITLE
check if .env variables are defined

### DIFF
--- a/classes/Tools/ToolBase.php
+++ b/classes/Tools/ToolBase.php
@@ -255,7 +255,14 @@ abstract class ToolBase {
             return false;
         }
 
-    	$env = ($this->env_variable) ? getenv($this->env_variable) : false;
+        $env = false;
+        if ($this->env_variable) {
+            if (defined($this->env_variable)) {
+                $env = constant($this->env_variable);
+            } else {
+                $env = getenv($this->env_variable);
+            }
+        }
         $enabled=get_option("ilab-media-tool-enabled-$this->toolName", $env);
 
         if ($enabled && isset($this->toolInfo['dependencies']))

--- a/classes/Utilities/EnvironmentOptions.php
+++ b/classes/Utilities/EnvironmentOptions.php
@@ -40,12 +40,18 @@ final class EnvironmentOptions {
 
 		if (is_array($envVariableName)) {
 			foreach($envVariableName as $envVariable) {
+                if (defined($envVariable)) {
+                    return constant($envVariable);
+                }
 				$envval = getenv($envVariable);
 				if ($envval) {
 					return $envval;
 				}
 			}
 		} else {
+            if (defined($envVariableName)) {
+                return constant($envVariableName);
+            }
 			$envval = getenv($envVariableName);
 			if ($envval) {
 				return $envval;

--- a/classes/Utilities/Logging/Logger.php
+++ b/classes/Utilities/Logging/Logger.php
@@ -41,7 +41,11 @@ class Logger {
             }
         }
 
-		$env = getenv('ILAB_MEDIA_DEBUGGING_ENABLED');
+        if (defined('ILAB_MEDIA_DEBUGGING_ENABLED')) {
+            $env = constant('ILAB_MEDIA_DEBUGGING_ENABLED');
+        } else {
+            $env = getenv('ILAB_MEDIA_DEBUGGING_ENABLED');
+        }
 		$enabled = ($this->useWPCLI) ?: get_option("ilab-media-tool-enabled-debugging", $env);
 
 		if ($enabled) {


### PR DESCRIPTION
On multi-threaded systems the .env file won't load consistently.
https://github.com/vlucas/phpdotenv/issues/219

We use bedrock to `define` all the variables we need and I thought it would be nice if the plugin would first check for defined variables