### PR TITLE
Add filter to change the storage prefix

### DIFF
--- a/classes/Tools/Storage/StorageTool.php
+++ b/classes/Tools/Storage/StorageTool.php
@@ -1128,7 +1128,9 @@ class StorageTool extends ToolBase {
         } else {
             $prefix = ($preserveFilePath && isset($data['prefix'])) ? $data['prefix'].DIRECTORY_SEPARATOR : StorageSettings::prefix($id);
         }
-
+		
+		$prefix = apply_filters( 'ilab_storage_prefix', $prefix );
+		
         $parts = explode('/', $filename);
         $bucketFilename = array_pop($parts);
 


### PR DESCRIPTION
@jawngee 
We have several websites and want to upload all images to the same bucket but separate folders for each of the website, so we have added the filter.
This filter allows to change the $prefix variable when uploading to the
storage, so if you want to upload all images to the certain folder in the
bucket, you can do it by changing prefix