### PR TITLE
Add a FAQ for existing images still being served on local path

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,10 @@ thing to happen to WordPress and web development in the history of ever.
 ##### Are you a paid shill for Imgix?
 
 No, I'm just one very enthusiastic customer.
+
+##### Existing images are still served from a local URL instead of the remote one
+
+ Only new uploads while Media Cloud plugin is enabled will be served with the new remote remote storage used.
+
+
+


### PR DESCRIPTION
I saw that some ppl asked the same question than me, adding this in the FAQ will save you some times.

Also, it'd be nice if the plugins offers a solution to process existing remote images. It will allow ppl to use your plugin not only in new installations, but also in previous and old ones.