### PR TITLE
Prevent Duplicate Images in Image Uploader UI

### DIFF
--- a/views/importer/importer.blade.php
+++ b/views/importer/importer.blade.php
@@ -75,30 +75,38 @@
 
             const backgroundImport = {{ ($background) ? 'true' : 'false' }};
             var postsToImport = {!! json_encode($posts, JSON_PRETTY_PRINT) !!};
+            
+            var lastThumb = {
+                id: null,
+                url: null
+            };
 
-            var lastThumbUrl = null;
-
-            const displayNextThumbnail = function(thumbUrl, icon) {
-                if (thumbUrl == null) {
+            /**
+             * @param {object} thumb - {id, url}
+             * @param {boolean} icon
+             */
+            const displayNextThumbnail = function(thumb, icon) {
+                if (thumb == undefined || thumb == null || !thumb.hasOwnProperty('url') || thumb.url == null || !thumb.hasOwnProperty('id') || thumb.id == null) {
                     return;
                 }
 
-                if (!icon && (thumbUrl == lastThumbUrl)) {
+                if (!icon && (lastThumb.id === thumb.id)) {
                     return;
                 }
                 
                 if (!icon && (displayedThumbs.length > 0)) {
-                    if (displayedThumbs[displayedThumbs.length - 1].attr('src') == thumbUrl) {
+                    if (displayedThumbs[displayedThumbs.length - 1].attr('src') == thumb.url) {
                         return;
                     }
                 }
 
                 var image = null;
                 if (!icon) {
-                    lastThumbUrl = thumbUrl;
-                    image = $('<div class="s3-importer-thumb ilab-hidden" style="background-image: url('+thumbUrl+')"></div>');
+                    lastThumb.url = thumb.url;
+                    lastThumb.id = thumb.id;
+                    image = $('<div class="s3-importer-thumb ilab-hidden" style="background-image: url('+thumb.url+')"></div>');
                 } else {
-                    image = $('<div class="s3-importer-image-icon ilab-hidden"><img src="'+thumbUrl+'"></div>');
+                    image = $('<div class="s3-importer-image-icon ilab-hidden"><img src="'+thumb.url+'"></div>');
                 }
 
                 image.prependTo('#s3-importer-thumbnails-container');
@@ -171,7 +179,13 @@
 
                 totalIndex++;
 
-                displayNextThumbnail(postsToImport[currentIndex].thumb, postsToImport[currentIndex].icon);
+                displayNextThumbnail(
+                    {
+                        id: postsToImport[currentIndex].currentID, 
+                        url: postsToImport[currentIndex].thumb
+                    }, 
+                    postsToImport[currentIndex].icon
+                );
 
                 $('#s3-importer-status-text').css({'visibility':'visible'});
                 $('#s3-importer-current').text((totalIndex + 1));
@@ -278,7 +292,13 @@
                         $('#s3-importer-instructions').css({display: 'none'});
                         $('#s3-importer-progress').css({display: 'block'});
 
-                        displayNextThumbnail(postsToImport[0].thumb, postsToImport[0].icon);
+                        displayNextThumbnail(
+                            {
+                                id: postsToImport[0].currentID, 
+                                url: postsToImport[0].thumb
+                            }, 
+                            postsToImport[0].icon
+                        );
 
                         $('#s3-importer-status-text').css({'visibility':'visible'});
                         $('#s3-importer-current').text(1);
@@ -303,7 +323,13 @@
                             $('#s3-importer-instructions').css({display: 'none'});
                             $('#s3-importer-progress').css({display: 'block'});
 
-                            displayNextThumbnail(response.first.thumb, response.first.icon);
+                            displayNextThumbnail(
+                                {
+                                    id: response.first.currentID, 
+                                    url: response.first.thumb
+                                }, 
+                                response.first.icon
+                            );
 
                             totalItems = response.total;
                             $('#s3-importer-status-text').css({'visibility':'visible'});
@@ -380,7 +406,10 @@
                             }
 
                             if (response.thumb != null) {
-                                displayNextThumbnail(response.thumb);
+                                displayNextThumbnail({
+                                    id: response.currentID, 
+                                    url: response.thumb
+                                });
                             }
 
                             $('#s3-timing-stats').css({display: 'inline-block'});


### PR DESCRIPTION
When the master images is uploaded to cloud storage but it's still in process, the importer process image will return the new imgix url rather than the old image url, but the image will still be the same. Since the urls do not match, the importer UI will show a duplicate image (one from imgix and one from the server). 

This PR changes `lastThumbUrl` to a  `lastThumb` object that looks like `{id, url}`. Then you can use the last image ID and current image ID to decide if the next image should be shown rather than the last thumb url and current thumb url. This prevents duplicate images from showing up in the importer.

Before the fix: One duplicate image was from the server and one was from imgix.
<img width="948" alt="Media Cloud importer process with duplicate images" src="https://user-images.githubusercontent.com/967608/61469493-e8326d80-a944-11e9-98fa-c2de8c00ce28.png">

After the fix with console logs: Same image ID comparison (before the Same ID would have shown a duplicate image)
<img width="1096" alt="Screen Shot 2019-07-18 at 10 02 37 AM" src="https://user-images.githubusercontent.com/967608/61469519-f2ed0280-a944-11e9-8af7-f4212538fe75.png">


