### PR TITLE
fix google storage - https was added twice

### DIFF
--- a/classes/Storage/Driver/GoogleCloud/GoogleStorage.php
+++ b/classes/Storage/Driver/GoogleCloud/GoogleStorage.php
@@ -348,7 +348,7 @@ class GoogleStorage implements StorageInterface {
 		}
 
 		$url = $object->gcsUri();
-		$url = str_replace('gs://',static::defaultDownloadUrl().'/', $url);
+		$url = str_replace('gs://', static::defaultDownloadUrl().'/', $url);
 
 		return $url;
 	}
@@ -378,7 +378,7 @@ class GoogleStorage implements StorageInterface {
 		$type = $info['contentType'];
 
 		$url = $object->gcsUri();
-		$url = str_replace('gs://','https://'.static::defaultDownloadUrl().'/', $url);
+		$url = str_replace('gs://', static::defaultDownloadUrl().'/', $url);
 
 		$presignedUrl = $object->signedUrl(new Timestamp(new \DateTime("+{$this->presignedURLExpiration} minutes")));
 
@@ -550,7 +550,7 @@ class GoogleStorage implements StorageInterface {
 
 		$object = $this->client->bucket($this->bucket)->object($key);
 		$url = $object->gcsUri();
-		$url = str_replace('gs://','https://'.static::defaultDownloadUrl().'/', $url);
+		$url = str_replace('gs://', static::defaultDownloadUrl().'/', $url);
 		return $url;
 	}
 	//endregion


### PR DESCRIPTION
When running the system test, the uploaded file could not be verified, because it linked to https://https://storage.googleapis.com/... 

This commit fixes that.