### PR TITLE
Load credentials from MCLOUD_STORAGE_GOOGLE_CREDENTIALS_FILE as well

### DIFF
--- a/classes/Storage/Driver/GoogleCloud/GoogleStorage.php
+++ b/classes/Storage/Driver/GoogleCloud/GoogleStorage.php
@@ -75,7 +75,7 @@ class GoogleStorage implements StorageInterface {
 			'ILAB_CLOUD_BUCKET'
 		]);
 
-		$credFile = Environment::Option(null, 'ILAB_CLOUD_GOOGLE_CREDENTIALS');
+		$credFile = Environment::Option(null, ['ILAB_CLOUD_GOOGLE_CREDENTIALS', 'MCLOUD_GOOGLE_CREDENTIALS_FILE']);
 		if (!empty($credFile)) {
 			if (file_exists($credFile)) {
 				$this->credentials = json_decode(file_get_contents($credFile), true);

--- a/classes/Storage/Driver/GoogleCloud/GoogleStorage.php
+++ b/classes/Storage/Driver/GoogleCloud/GoogleStorage.php
@@ -75,7 +75,7 @@ class GoogleStorage implements StorageInterface {
 			'ILAB_CLOUD_BUCKET'
 		]);
 
-		$credFile = Environment::Option(null, ['ILAB_CLOUD_GOOGLE_CREDENTIALS', 'MCLOUD_GOOGLE_CREDENTIALS_FILE']);
+		$credFile = Environment::Option('mcloud-storage-google-credentials-file', 'ILAB_CLOUD_GOOGLE_CREDENTIALS');
 		if (!empty($credFile)) {
 			if (file_exists($credFile)) {
 				$this->credentials = json_decode(file_get_contents($credFile), true);


### PR DESCRIPTION
Fixes https://github.com/Interfacelab/ilab-media-tools/issues/97