### PR TITLE
fix wrong variable name

### DIFF
--- a/classes/Tasks/AttachmentTask.php
+++ b/classes/Tasks/AttachmentTask.php
@@ -104,7 +104,7 @@ abstract class AttachmentTask extends Task {
 
 			if (isset($options['limit'])) {
 				$args['posts_per_page'] = $options['limit'];
-				if (isset($assoc_args['offset'])) {
+				if (isset($options['offset'])) {
 					$args['offset'] = $options['offset'];
 				}
 			} else {


### PR DESCRIPTION
Wrong variable name for offset options. 
wp mediacloud regenerate --limit=10 page=5  doesn't work otherwise. (always on page 1)