### PR TITLE
Remove 'block_categories' deprecation warning in WordPress 5.8

### DIFF
--- a/classes/Tools/Video/Driver/Mux/MuxTool.php
+++ b/classes/Tools/Video/Driver/Mux/MuxTool.php
@@ -205,7 +205,7 @@ class MuxTool extends Tool
             ] );
         } );
         add_filter(
-            'block_categories',
+            'block_categories_all',
             function ( $categories, $post ) {
             foreach ( $categories as $category ) {
                 if ( $category['slug'] === 'mediacloud' ) {


### PR DESCRIPTION
Fixes #164