### PR TITLE
feat: add support to use Google Application Default Credentials

### DIFF
--- a/classes/Tools/Storage/Driver/GoogleCloud/GoogleStorageSettings.php
+++ b/classes/Tools/Storage/Driver/GoogleCloud/GoogleStorageSettings.php
@@ -26,6 +26,7 @@ use MediaCloud\Plugin\Utilities\Logging\Logger;
  *
  * @property-read string credentials
  * @property string bucket
+ * @property bool useApplicationDefaultCredentials
  * @property bool useBucketPolicyOnly
  * @property bool usePresignedURLs
  * @property bool usePresignedURLsForImages
@@ -46,6 +47,7 @@ class GoogleStorageSettings extends ToolSettings {
 	 */
 	protected $settingsMap = [
 		'bucket' => ['mcloud-storage-google-bucket', ['ILAB_CLOUD_GOOGLE_BUCKET', 'ILAB_AWS_S3_BUCKET', 'ILAB_CLOUD_BUCKET'], null],
+		'useApplicationDefaultCredentials' => ['mcloud-storage-application-default-credentials', null, false],
 		'useBucketPolicyOnly' => ['mcloud-storage-bucket-policy-only', null, false],
 		'usePresignedURLs' => ['mcloud-storage-use-presigned-urls', null, false],
 		'presignedURLExpiration' => ['mcloud-storage-presigned-expiration', null, 300],

--- a/config/storage/google.config.php
+++ b/config/storage/google.config.php
@@ -23,10 +23,17 @@ return [
                 "display-order" => 1,
                 "type" => "text-area",
             ],
+			"mcloud-storage-application-default-credentials" => [
+				"title" => "Use Application Default Credentials",
+				"description" => "Set to true when running your workload on a Google Cloud solution where these are automatically provided. See <a target='_blank' href='https://cloud.google.com/docs/authentication/application-default-credentials'>this documentation</a> for more information. If you enable this, you don't need to provide a JSON file with credentials.",
+				"display-order" => 2,	
+				"type" => "checkbox",
+				"default" => false,
+			],
             "mcloud-storage-google-bucket" => [
                 "title" => "Bucket",
                 "description" => "The bucket you wish to store your media in.  Must not be blank.",
-                "display-order" => 2,
+                "display-order" => 3,
                 "type" => "text-field",
             ],
 	        "mcloud-storage-bucket-policy-only" => [


### PR DESCRIPTION
This PR adds support to rely on Google's Application Default Credentials, so you don't have to generate & provide a Service Account key. 

This option is only useful when running Wordpress on Google Cloud - whether it's on AppEngine, Cloud Run, a Compute Instance or even on GKE (with Workload Identity enabled); and automatically uses the Service Account credentials that belong to the SA running the workload. 